### PR TITLE
Add custom_protocol_api plugin

### DIFF
--- a/plugins/custom_protocol_api/CMakeLists.txt
+++ b/plugins/custom_protocol_api/CMakeLists.txt
@@ -1,0 +1,51 @@
+set(CURRENT_TARGET custom_protocol_api)
+
+list(APPEND CURRENT_TARGET_HEADERS
+        include/graphene/plugins/custom_protocol_api/custom_protocol_api.hpp
+        include/graphene/plugins/custom_protocol_api/custom_protocol_api_visitor.hpp
+        include/graphene/plugins/custom_protocol_api/custom_protocol_api_object.hpp
+)
+
+list(APPEND CURRENT_TARGET_SOURCES
+        custom_protocol_api.cpp
+        custom_protocol_api_visitor.cpp
+)
+
+if(BUILD_SHARED_LIBRARIES)
+    add_library(graphene_${CURRENT_TARGET} SHARED
+                ${CURRENT_TARGET_HEADERS}
+                ${CURRENT_TARGET_SOURCES}
+    )
+else()
+    add_library(graphene_${CURRENT_TARGET} STATIC
+                ${CURRENT_TARGET_HEADERS}
+                ${CURRENT_TARGET_SOURCES}
+    )
+endif()
+
+add_library(graphene::${CURRENT_TARGET} ALIAS graphene_${CURRENT_TARGET})
+
+set_property(TARGET graphene_${CURRENT_TARGET} PROPERTY EXPORT_NAME ${CURRENT_TARGET})
+
+target_link_libraries(
+        graphene_${CURRENT_TARGET}
+        graphene_chain
+        graphene::chain_plugin
+        graphene::network
+        graphene::api
+        appbase
+)
+
+target_include_directories(
+        graphene_${CURRENT_TARGET}
+        PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include"
+        "${CMAKE_CURRENT_SOURCE_DIR}/../../"
+)
+
+install(TARGETS
+        graphene_${CURRENT_TARGET}
+
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+        )

--- a/plugins/custom_protocol_api/custom_protocol_api.cpp
+++ b/plugins/custom_protocol_api/custom_protocol_api.cpp
@@ -1,0 +1,153 @@
+#include <boost/program_options/options_description.hpp>
+#include <graphene/plugins/custom_protocol_api/custom_protocol_api.hpp>
+#include <graphene/plugins/custom_protocol_api/custom_protocol_api_object.hpp>
+#include <graphene/plugins/custom_protocol_api/custom_protocol_api_visitor.hpp>
+#include <graphene/api/account_api_object.hpp>
+#include <graphene/chain/index.hpp>
+#include <graphene/chain/chain_objects.hpp>
+#include <graphene/chain/operation_notification.hpp>
+
+#define CHECK_ARG_SIZE(_S)                                 \
+   FC_ASSERT(                                              \
+       args.args->size() == _S,                            \
+       "Expected #_S argument(s), was ${n}",               \
+       ("n", args.args->size()) );
+
+#define CHECK_ARG_MIN_SIZE(_S, _M)                         \
+   FC_ASSERT(                                              \
+       args.args->size() >= _S && args.args->size() <= _M, \
+       "Expected #_S (maximum #_M) argument(s), was ${n}", \
+       ("n", args.args->size()) );
+
+#define GET_OPTIONAL_ARG(_I, _T, _D)   \
+   (args.args->size() > _I) ?          \
+   (args.args->at(_I).as<_T>()) :      \
+   static_cast<_T>(_D)
+
+#ifndef DEFAULT_VOTE_LIMIT
+#  define DEFAULT_VOTE_LIMIT 10000
+#endif
+
+namespace graphene { namespace plugins { namespace custom_protocol_api {
+
+    struct custom_protocol_api_plugin::impl final {
+        impl(): database_(appbase::app().get_plugin<chain::plugin>().db()) {
+        }
+
+        ~impl() = default;
+
+        void on_operation(const operation_notification& note) {
+            try {
+                /// plugins shouldn't ever throw
+                note.op.visit(custom_protocol_api::operation_visitor(database(),custom_protocol_store_size));
+            } catch (const fc::exception& e) {
+                edump((e.to_detail_string()));
+            } catch (...) {
+                elog("unhandled exception");
+            }
+        }
+
+        graphene::chain::database& database() {
+            return database_;
+        }
+
+        graphene::chain::database& database() const {
+            return database_;
+        }
+
+        uint8_t custom_protocol_store_size = 10;
+
+    private:
+        graphene::chain::database& database_;
+    };
+
+
+    void custom_protocol_api_plugin::plugin_startup() {
+        wlog("custom_protocol_api plugin: plugin_startup()");
+    }
+
+    void custom_protocol_api_plugin::plugin_shutdown() {
+        wlog("custom_protocol_api plugin: plugin_shutdown()");
+    }
+
+    const std::string& custom_protocol_api_plugin::name() {
+        static const std::string name = "custom_protocol_api";
+        return name;
+    }
+
+    custom_protocol_api_plugin::custom_protocol_api_plugin() {
+    }
+
+    void custom_protocol_api_plugin::set_program_options(
+        boost::program_options::options_description& cli,
+        boost::program_options::options_description& cfg
+    ) {
+        cli.add_options()
+            ("custom-protocol-store-size", boost::program_options::value<uint8_t>()->default_value(10),
+                "Set the maximum store size for custom protocols used by account");
+        cfg.add(cli);
+    }
+
+    void custom_protocol_api_plugin::plugin_initialize(const boost::program_options::variables_map& options) {
+        pimpl = std::make_unique<impl>();
+        auto& db = pimpl->database();
+        db.post_apply_operation.connect([&](const operation_notification& note) {
+            pimpl->on_operation(note);
+        });
+        add_plugin_index<custom_protocol_api::custom_protocol_index>(db);
+
+        if (options.count("custom-protocol-store-size")) {
+            uint8_t _custom_protocol_store_size = options["custom-protocol-store-size"].as<uint8_t>();
+            pimpl->custom_protocol_store_size = _custom_protocol_store_size;
+        }
+
+        JSON_RPC_REGISTER_API(name());
+    }
+
+    custom_protocol_api_plugin::~custom_protocol_api_plugin() = default;
+
+    DEFINE_API(custom_protocol_api_plugin, get_account) {
+        CHECK_ARG_SIZE(2)
+        auto account = args.args->at(0).as<string>();
+        auto custom_protocol_id = args.args->at(1).as<string>();
+        auto& db = pimpl->database();
+        return db.with_weak_read_lock([&]() {
+            const auto &idx = db.get_index<account_index>().indices().get<by_name>();
+            const auto &vidx = db.get_index<witness_vote_index>().indices().get<by_account_witness>();
+            account_api_object result;
+
+            auto itr = idx.find(account);
+            if (itr != idx.end()) {
+                result=account_api_object(*itr, db);
+
+                auto vitr = vidx.lower_bound(boost::make_tuple(itr->id, witness_id_type()));
+                while (vitr != vidx.end() && vitr->account == itr->id) {
+                    result.witness_votes.insert(db.get(vitr->witness).owner);
+                    ++vitr;
+                }
+
+                if(""!=custom_protocol_id){
+                    result.custom_sequence=0;
+                    result.custom_sequence_block_num=0;
+                    const auto &cpidx = db.get_index<custom_protocol_index>().indices().get<by_account_custom_sequence_block_num>();
+                    auto cpitr = cpidx.lower_bound(boost::make_tuple(account, uint64_t(-1)));
+                    bool find=false;
+                    while(!find && cpitr != cpidx.end() && cpitr->account == account){
+                        const auto& custom_protocol_item = *cpitr;
+                        ++cpitr;
+                        if(custom_protocol_id==custom_protocol_item.custom_protocol_id){
+                            result.custom_sequence=custom_protocol_item.custom_sequence;
+                            result.custom_sequence_block_num=custom_protocol_item.custom_sequence_block_num;
+                            find=true;
+                        }
+                    }
+                }
+            }
+            else{
+                FC_ASSERT(false,"Account with name \"${name}\" not found.", ("name", account) );
+            }
+            return result;
+        });
+    }
+
+} } } // graphene::plugins::custom_protocol_api

--- a/plugins/custom_protocol_api/custom_protocol_api_visitor.cpp
+++ b/plugins/custom_protocol_api/custom_protocol_api_visitor.cpp
@@ -1,0 +1,52 @@
+#include <boost/algorithm/string.hpp>
+#include <graphene/plugins/custom_protocol_api/custom_protocol_api_object.hpp>
+#include <graphene/plugins/custom_protocol_api/custom_protocol_api_visitor.hpp>
+
+namespace graphene { namespace plugins { namespace custom_protocol_api {
+
+    operation_visitor::operation_visitor(database& db, uint8_t custom_protocol_store_size)
+        : _db(db), _custom_protocol_store_size(custom_protocol_store_size) {
+    }
+
+    void operation_visitor::operator()(const custom_operation& op) const {
+        std::vector<account_name_type> accounts;
+        for (const auto &i : op.required_active_auths) {
+            accounts.emplace_back(i);
+        }
+        for (const auto &i : op.required_regular_auths) {
+            accounts.emplace_back(i);
+        }
+        for (const auto i : accounts) {
+            bool find=false;
+            const auto &idx = _db.get_index<custom_protocol_index>().indices().get<by_account_custom_sequence_block_num>();
+            auto itr = idx.lower_bound(boost::make_tuple(i, uint64_t(-1) ));
+            uint8_t custom_protocol_counter=0;
+            while(!find && itr != idx.end() && itr->account == i){
+                const auto& custom_protocol_item = *itr;
+                ++itr;
+                custom_protocol_counter++;
+                if(op.id == custom_protocol_item.custom_protocol_id){
+                    find=true;
+                    _db.modify(custom_protocol_item, [&](custom_protocol_object& c){
+                        c.custom_sequence++;
+                        c.custom_sequence_block_num = 1 + _db.head_block_num();//head_block_num contains previous block num
+                    });
+                }
+                else{
+                    if(custom_protocol_counter>=_custom_protocol_store_size){
+                        _db.remove(custom_protocol_item);
+                    }
+                }
+            }
+            if(!find){
+                _db.create<custom_protocol_object>([&](custom_protocol_object& c) {
+                    c.account=i;
+                    c.custom_protocol_id=op.id;
+                    c.custom_sequence = 1;
+                    c.custom_sequence_block_num = 1 + _db.head_block_num();//head_block_num contains previous block num
+                });
+            }
+        }
+    }
+
+} } } // graphene::plugins::custom_protocol_api

--- a/plugins/custom_protocol_api/include/graphene/plugins/custom_protocol_api/custom_protocol_api.hpp
+++ b/plugins/custom_protocol_api/include/graphene/plugins/custom_protocol_api/custom_protocol_api.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <appbase/application.hpp>
+#include <graphene/plugins/chain/plugin.hpp>
+#include <graphene/api/account_api_object.hpp>
+#include <graphene/plugins/custom_protocol_api/custom_protocol_api_object.hpp>
+#include <graphene/plugins/custom_protocol_api/custom_protocol_api_visitor.hpp>
+
+namespace graphene { namespace plugins { namespace custom_protocol_api {
+    using plugins::json_rpc::msg_pack;
+    using graphene::api::account_api_object;
+    using graphene::plugins::custom_protocol_api::custom_protocol_object;
+    using namespace graphene::chain;
+    DEFINE_API_ARGS(get_account, msg_pack, account_api_object)
+
+    class custom_protocol_api_plugin final: public appbase::plugin<custom_protocol_api_plugin> {
+    public:
+        APPBASE_PLUGIN_REQUIRES (
+            (chain::plugin)
+            (json_rpc::plugin)
+        )
+
+        DECLARE_API(
+            /**
+             * @brief Get accaount by name with custom protocol reference by id
+             * @param name Name of the account
+             * @param custom_protocol Id of the custom protocol
+             * @return The account with custom protocol reference if founded in custom_sequence and custom_sequence_block_num
+             */
+            (get_account)
+        )
+
+        custom_protocol_api_plugin();
+        ~custom_protocol_api_plugin();
+
+        void set_program_options(
+            boost::program_options::options_description&,
+            boost::program_options::options_description& config_file_options
+        ) override;
+
+        static const std::string& name();
+
+        void plugin_initialize(const boost::program_options::variables_map& options) override;
+
+        void plugin_startup() override;
+        void plugin_shutdown() override;
+
+    private:
+        struct impl;
+        std::unique_ptr<impl> pimpl;
+    };
+} } } // graphene::plugins::custom_protocol_api

--- a/plugins/custom_protocol_api/include/graphene/plugins/custom_protocol_api/custom_protocol_api_object.hpp
+++ b/plugins/custom_protocol_api/include/graphene/plugins/custom_protocol_api/custom_protocol_api_object.hpp
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <appbase/application.hpp>
+#include <graphene/plugins/chain/plugin.hpp>
+#include <graphene/protocol/types.hpp>
+#include <boost/multi_index/composite_key.hpp>
+#include <graphene/chain/chain_object_types.hpp>
+#include <graphene/chain/content_object.hpp>
+
+namespace graphene { namespace plugins { namespace custom_protocol_api {
+    using namespace graphene::chain;
+    using chainbase::object;
+    using chainbase::object_id;
+    using chainbase::allocator;
+
+        //
+        // Plugins should #define their SPACE_ID's so plugins with
+        // conflicting SPACE_ID assignments can be compiled into the
+        // same binary (by simply re-assigning some of the conflicting #defined
+        // SPACE_ID's in a build script).
+        //
+        // Assignment of SPACE_ID's cannot be done at run-time because
+        // various template automagic depends on them being known at compile
+        // time.
+    	//
+    	// Take ID as new plugin catalogue counter
+        //
+    #ifndef CUSTOM_PROTOCOL_SPACE_ID
+    #define CUSTOM_PROTOCOL_SPACE_ID 25
+    #endif
+
+    enum custom_protocol_api_object_type {
+        custom_protocol_object_type = (CUSTOM_PROTOCOL_SPACE_ID << 8)
+    };
+
+    class custom_protocol_object: public object<custom_protocol_object_type, custom_protocol_object> {
+    public:
+        template<typename Constructor, typename Allocator>
+        custom_protocol_object(Constructor&& c, allocator<Allocator> a) {
+            c(*this);
+        }
+
+        id_type id;
+        account_name_type account;
+        account_name_type custom_protocol_id;
+        uint64_t custom_sequence = 0;
+        uint64_t custom_sequence_block_num = 0;
+    };
+
+    typedef object_id<custom_protocol_object> custom_protocol_id_type;
+
+    using namespace boost::multi_index;
+
+    struct by_account_custom_sequence_block_num;
+    using custom_protocol_index = multi_index_container<
+        custom_protocol_object,
+        indexed_by<
+            ordered_unique<
+                tag<by_id>,
+                member<custom_protocol_object, custom_protocol_id_type, &custom_protocol_object::id>>,
+            ordered_non_unique<
+                tag<by_account_custom_sequence_block_num>,
+                composite_key<
+                    custom_protocol_object,
+                    member<custom_protocol_object, account_name_type, &custom_protocol_object::account>,
+                    member<custom_protocol_object, uint64_t, &custom_protocol_object::custom_sequence_block_num>
+                >,
+                composite_key_compare <std::less<account_name_type>, std::greater<uint64_t>>
+            >
+        >,
+        allocator<custom_protocol_object>>;
+} } } // graphene::api
+
+
+CHAINBASE_SET_INDEX_TYPE(
+    graphene::plugins::custom_protocol_api::custom_protocol_object,
+    graphene::plugins::custom_protocol_api::custom_protocol_index)
+FC_REFLECT((graphene::plugins::custom_protocol_api::custom_protocol_object),(account)(id)(custom_sequence)(custom_sequence_block_num));

--- a/plugins/custom_protocol_api/include/graphene/plugins/custom_protocol_api/custom_protocol_api_visitor.hpp
+++ b/plugins/custom_protocol_api/include/graphene/plugins/custom_protocol_api/custom_protocol_api_visitor.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <graphene/plugins/custom_protocol_api/custom_protocol_api_object.hpp>
+#include <boost/algorithm/string.hpp>
+
+namespace graphene { namespace plugins { namespace custom_protocol_api {
+    using graphene::plugins::custom_protocol_api::custom_protocol_object;
+    struct operation_visitor {
+        operation_visitor(database& db, const uint8_t custom_protocol_store_size);
+        using result_type = void;
+
+        database& _db;
+        uint8_t _custom_protocol_store_size;
+
+        void operator()(const custom_operation& op) const;
+
+        template<typename Op>
+        void operator()(Op&&) const {
+        } /// ignore all other ops
+    };
+
+} } } // graphene::plugins::custom_protocol_api

--- a/programs/vizd/CMakeLists.txt
+++ b/programs/vizd/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(
         graphene::committee_api
         graphene::invite_api
         graphene::paid_subscription_api
+        graphene::custom_protocol_api
         ${MONGO_LIB}
         graphene_protocol
         fc

--- a/programs/vizd/main.cpp
+++ b/programs/vizd/main.cpp
@@ -27,6 +27,7 @@
 #include <graphene/plugins/committee_api/committee_api.hpp>
 #include <graphene/plugins/invite_api/invite_api.hpp>
 #include <graphene/plugins/paid_subscription_api/paid_subscription_api.hpp>
+#include <graphene/plugins/custom_protocol_api/custom_protocol_api.hpp>
 
 #include <fc/interprocess/signals.hpp>
 #include <fc/log/console_appender.hpp>
@@ -84,6 +85,7 @@ namespace graphene {
             appbase::app().register_plugin<graphene::plugins::committee_api::committee_api>();
             appbase::app().register_plugin<graphene::plugins::invite_api::invite_api>();
             appbase::app().register_plugin<graphene::plugins::paid_subscription_api::paid_subscription_api>();
+            appbase::app().register_plugin<graphene::plugins::custom_protocol_api::custom_protocol_api_plugin>();
             ///plugins
         };
     }

--- a/share/vizd/config/config.ini
+++ b/share/vizd/config/config.ini
@@ -66,7 +66,11 @@ inc-shared-file-size = 2G
 # and resizes. The optimal strategy is do checking of the free space, but not very often.
 block-num-check-free-size = 1000 # each 3000 seconds
 
-plugin = chain p2p json_rpc webserver network_broadcast_api witness test_api database_api private_message follow social_network tags account_by_key operation_history account_history block_info raw_block witness_api
+plugin = witness_api
+plugin = chain p2p json_rpc webserver network_broadcast_api database_api
+plugin = account_history operation_history
+plugin = committee_api invite_api paid_subscription_api custom_protocol_api
+plugin = account_by_key block_info raw_block
 
 # Remove votes before defined block, should increase performance
 clear-votes-before-block = 0 # clear votes after each cashout

--- a/share/vizd/config/config_testnet.ini
+++ b/share/vizd/config/config_testnet.ini
@@ -69,7 +69,7 @@ block-num-check-free-size = 1000 # each 3000 seconds
 plugin = witness witness_api
 plugin = chain p2p json_rpc webserver network_broadcast_api database_api
 plugin = account_history operation_history
-plugin = committee_api invite_api paid_subscription_api
+plugin = committee_api invite_api paid_subscription_api custom_protocol_api
 plugin = account_by_key block_info raw_block
 
 # Remove votes before defined block, should increase performance


### PR DESCRIPTION
To support flexible store for last custom protocol operations by account as account custom sequencer.
Example: quotes from exchange account distributed by custom operation will be available by targeted extract. Many custom protocols will be not conflict for account custom sequencer namespace.

API plugin: custom_protocol_api
API method: get_account
Params:
- Account name
- Custom protocol id

Additional config option for expand usability:
custom-protocol-store-size = 10 # custom protocol sequencers limit to account

Updating public full nodes is recommended.