### PR TITLE
feat: snapshot plugin for fast node recovery

### DIFF
--- a/.qoder/docs/plugins.md
+++ b/.qoder/docs/plugins.md
@@ -601,6 +601,50 @@ Get raw serialized blocks.
 
 ---
 
+### `snapshot`
+**Status:** Active
+**Category:** API / Infrastructure
+**Dependencies:** `json_rpc`, `chain`
+
+Export, verify, and import full blockchain state snapshots.
+
+**Purpose:**
+- Export full chainbase state (31 object types) to a binary snapshot file
+- Verify snapshot integrity against current DB state
+- Enable fast node startup from snapshot instead of hours-long replay
+- Automatic periodic snapshots and on-demand export via SIGUSR1
+
+**JSON-RPC Methods:**
+
+| Method | Description |
+|---|---|
+| `snapshot.snapshot_export` | Export state to file. Arg: file path |
+| `snapshot.snapshot_info` | Read snapshot header without loading. Arg: file path |
+| `snapshot.snapshot_verify` | Compare snapshot against current DB state. Arg: file path |
+
+**Config options:**
+```ini
+# Auto-export every N blocks (0 = disabled, 28800 = ~1 day)
+snapshot-every = 0
+
+# Directory for snapshot files (default: data_dir)
+snapshot-dir =
+```
+
+**CLI options (in chain plugin):**
+```
+--load-snapshot /path/to/snapshot.bin   Load state from snapshot instead of replay
+```
+
+**Manual trigger:**
+```bash
+kill -SIGUSR1 $(pidof vizd)
+```
+
+**Snapshot file format:** Binary with JSON header. Contains magic bytes (`VIZSNAP`), format version, JSON metadata (block number, timestamp, chain_id, SHA256 hash, section offsets), and binary payload with all chainbase objects serialized via `fc::raw::pack`.
+
+---
+
 ## Witness/Producer Plugins
 
 ### `witness`

--- a/.qoder/repowiki/en/content/Plugin System.md
+++ b/.qoder/repowiki/en/content/Plugin System.md
@@ -339,6 +339,7 @@ The following plugins are part of the built-in set. Each plugin exposes specific
 - p2p: Peer-to-peer networking and broadcasting.
 - mongo_db: MongoDB integration for archival/indexing.
 - json_rpc: JSON-RPC dispatcher and method registry.
+- snapshot: Full chainbase state export/import for fast node recovery (API: snapshot_export, snapshot_info, snapshot_verify; CLI: --load-snapshot; auto-export via --snapshot-every; manual trigger via SIGUSR1).
 - Additional plugins include: account_by_key, auth_util, block_info, committee_api, custom_protocol_api, debug_node, follow, invite_api, network_broadcast_api, operation_history, paid_subscription_api, private_message, raw_block, social_network, tags, test_api, witness, witness_api.
 
 **Section sources**

--- a/libraries/chain/include/graphene/chain/content_object.hpp
+++ b/libraries/chain/include/graphene/chain/content_object.hpp
@@ -267,3 +267,19 @@ CHAINBASE_SET_INDEX_TYPE(graphene::chain::content_type_object, graphene::chain::
 
 CHAINBASE_SET_INDEX_TYPE(graphene::chain::content_vote_object, graphene::chain::content_vote_index)
 
+FC_REFLECT((graphene::chain::content_object),
+    (id)(parent_author)(parent_permlink)(author)(permlink)
+    (last_update)(created)(active)(last_payout)
+    (depth)(children)(children_rshares)
+    (net_rshares)(abs_rshares)(vote_rshares)
+    (cashout_time)(total_vote_weight)
+    (curation_percent)(consensus_curation_percent)
+    (payout_value)(shares_payout_value)(curator_payout_value)(beneficiary_payout_value)
+    (author_rewards)(net_votes)(root_content)(beneficiaries))
+
+FC_REFLECT((graphene::chain::content_type_object),
+    (id)(content)(title)(body)(json_metadata))
+
+FC_REFLECT((graphene::chain::content_vote_object),
+    (id)(voter)(content)(weight)(rshares)(vote_percent)(last_update)(num_changes))
+

--- a/libraries/chain/include/graphene/chain/database.hpp
+++ b/libraries/chain/include/graphene/chain/database.hpp
@@ -12,6 +12,7 @@
 #include <fc/log/logger.hpp>
 
 #include <map>
+#include <atomic>
 
 namespace graphene { namespace chain {
 
@@ -52,6 +53,21 @@ namespace graphene { namespace chain {
             bool _is_producing = false;
 
             bool _log_hardforks = true;
+
+            bool is_paused() const {
+                return _paused.load(std::memory_order_acquire);
+            }
+
+            void set_paused(bool p) {
+                _paused.store(p, std::memory_order_release);
+                if (p) {
+                    ilog("Database processing PAUSED");
+                } else {
+                    ilog("Database processing RESUMED");
+                }
+            }
+
+            std::atomic<bool> _paused{false};
 
             enum validation_steps {
                 skip_nothing = 0,

--- a/libraries/chain/include/graphene/chain/proposal_object.hpp
+++ b/libraries/chain/include/graphene/chain/proposal_object.hpp
@@ -143,3 +143,14 @@ namespace graphene { namespace chain {
 
 CHAINBASE_SET_INDEX_TYPE(graphene::chain::proposal_object, graphene::chain::proposal_index);
 CHAINBASE_SET_INDEX_TYPE(graphene::chain::required_approval_object, graphene::chain::required_approval_index);
+
+FC_REFLECT((graphene::chain::proposal_object),
+    (id)(author)(title)(memo)(expiration_time)(review_period_time)
+    (proposed_operations)
+    (required_active_approvals)(available_active_approvals)
+    (required_master_approvals)(available_master_approvals)
+    (required_regular_approvals)(available_regular_approvals)
+    (available_key_approvals))
+
+FC_REFLECT((graphene::chain::required_approval_object),
+    (id)(account)(proposal))

--- a/libraries/chain/include/graphene/chain/witness_objects.hpp
+++ b/libraries/chain/include/graphene/chain/witness_objects.hpp
@@ -303,6 +303,8 @@ FC_REFLECT(
 CHAINBASE_SET_INDEX_TYPE(graphene::chain::witness_object, graphene::chain::witness_index)
 
 CHAINBASE_SET_INDEX_TYPE(graphene::chain::witness_vote_object, graphene::chain::witness_vote_index)
+
+FC_REFLECT((graphene::chain::witness_vote_object), (id)(witness)(account))
 FC_REFLECT((graphene::chain::witness_schedule_object),
         (id)(current_virtual_time)(next_shuffle_block_num)(current_shuffled_witnesses)(num_scheduled_witnesses)
                 (median_props)(majority_version)

--- a/plugins/chain/CMakeLists.txt
+++ b/plugins/chain/CMakeLists.txt
@@ -32,7 +32,9 @@ target_link_libraries(
         graphene::json_rpc
 )
 target_include_directories(graphene_${CURRENT_TARGET}
-                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" "${CMAKE_CURRENT_SOURCE_DIR}/../../")
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include"
+                           "${CMAKE_CURRENT_SOURCE_DIR}/../../"
+                           "${CMAKE_CURRENT_SOURCE_DIR}/../snapshot/include")
 
 install(TARGETS
         graphene_${CURRENT_TARGET}

--- a/plugins/chain/include/graphene/plugins/chain/plugin.hpp
+++ b/plugins/chain/include/graphene/plugins/chain/plugin.hpp
@@ -47,6 +47,11 @@ namespace graphene {
 
                 bool block_is_on_preferred_chain(const protocol::block_id_type &block_id);
 
+                // Pause/resume block processing (for snapshots, maintenance)
+                void pause();
+                void resume();
+                bool is_paused() const;
+
                 void check_time_in_block(const protocol::signed_block &block);
 
                 template<typename MultiIndexType>

--- a/plugins/chain/plugin.cpp
+++ b/plugins/chain/plugin.cpp
@@ -1,3 +1,5 @@
+// Must be before chain headers: provides fc::raw overloads for interprocess types
+#include <fc/interprocess/container.hpp>
 #include <graphene/plugins/snapshot/chainbase_raw.hpp>
 #include <graphene/chain/database_exceptions.hpp>
 #include <graphene/chain/database.hpp>

--- a/plugins/chain/plugin.cpp
+++ b/plugins/chain/plugin.cpp
@@ -1,3 +1,4 @@
+#include <graphene/plugins/snapshot/chainbase_raw.hpp>
 #include <graphene/chain/database_exceptions.hpp>
 #include <graphene/chain/database.hpp>
 #include <graphene/chain/global_property_object.hpp>

--- a/plugins/chain/plugin.cpp
+++ b/plugins/chain/plugin.cpp
@@ -173,15 +173,13 @@ namespace chain {
     // Helper: remove all objects of a given type from the database
     template<typename IndexType, typename ObjectType>
     void clear_index(graphene::chain::database &db) {
-        const auto &idx = db.get_index<IndexType>().indices().template get<graphene::chain::by_id>();
+        const auto &idx = db.get_index<IndexType>().indices();
         std::vector<typename ObjectType::id_type> ids;
-        ids.reserve(std::distance(idx.begin(), idx.end()));
-        for (auto itr = idx.begin(); itr != idx.end(); ++itr) {
-            ids.push_back(itr->id);
+        for (const auto &obj : idx) {
+            ids.push_back(obj.id);
         }
         for (const auto &id : ids) {
-            const auto &obj = db.get<ObjectType>(id);
-            db.remove(obj);
+            db.remove(db.get<ObjectType>(id));
         }
     }
 

--- a/plugins/chain/plugin.cpp
+++ b/plugins/chain/plugin.cpp
@@ -313,7 +313,7 @@ namespace chain {
                 ("b", header.head_block_num));
             ilog("Snapshot block ${b} signature verified (witness: ${w}, signee: ${s})",
                 ("b", header.head_block_num)("w", block->witness)
-                ("s", std::string(signee)));
+                ("s", signee.to_base58()));
         } catch (const fc::exception &e) {
             elog("Block ${b} signature verification failed: ${e}",
                  ("b", header.head_block_num)("e", e.to_detail_string()));

--- a/plugins/chain/plugin.cpp
+++ b/plugins/chain/plugin.cpp
@@ -114,6 +114,11 @@ namespace chain {
     }
 
     bool plugin::plugin_impl::accept_block(const protocol::signed_block &block, bool currently_syncing, uint32_t skip) {
+        if (db.is_paused()) {
+            ilog("chain: block #${n} rejected — database is paused", ("n", block.block_num()));
+            return false;
+        }
+
         if (currently_syncing && block.block_num() % 10000 == 0) {
             ilog("Syncing Blockchain --- Got block: #${n} time: ${t} producer: ${p}",
                  ("t", block.timestamp)("n", block.block_num())("p", block.witness));
@@ -404,6 +409,10 @@ namespace chain {
     }
 
     void plugin::plugin_impl::accept_transaction(const protocol::signed_transaction &trx) {
+        if (db.is_paused()) {
+            FC_THROW_EXCEPTION(graphene::chain::plugin_exception, "Database is paused, transactions not accepted");
+        }
+
         uint32_t skip = db.validate_transaction(trx, db.skip_apply_transaction);
 
         if (single_write_thread) {
@@ -683,6 +692,18 @@ namespace chain {
 
     void plugin::check_time_in_block(const protocol::signed_block &block) {
         my->check_time_in_block(block);
+    }
+
+    void plugin::pause() {
+        my->db.set_paused(true);
+    }
+
+    void plugin::resume() {
+        my->db.set_paused(false);
+    }
+
+    bool plugin::is_paused() const {
+        return my->db.is_paused();
     }
 
 }

--- a/plugins/chain/plugin.cpp
+++ b/plugins/chain/plugin.cpp
@@ -1,11 +1,28 @@
 #include <graphene/chain/database_exceptions.hpp>
 #include <graphene/chain/database.hpp>
+#include <graphene/chain/global_property_object.hpp>
+#include <graphene/chain/account_object.hpp>
+#include <graphene/chain/witness_objects.hpp>
+#include <graphene/chain/content_object.hpp>
+#include <graphene/chain/chain_objects.hpp>
+#include <graphene/chain/proposal_object.hpp>
+#include <graphene/chain/committee_objects.hpp>
+#include <graphene/chain/invite_objects.hpp>
+#include <graphene/chain/paid_subscription_objects.hpp>
+#include <graphene/chain/block_summary_object.hpp>
+#include <graphene/chain/transaction_object.hpp>
+#include <graphene/chain/chain_object_types.hpp>
 #include <graphene/plugins/chain/plugin.hpp>
+#include <graphene/plugins/snapshot/snapshot_format.hpp>
 
 #include <fc/io/json.hpp>
+#include <fc/io/raw.hpp>
+#include <fc/crypto/sha256.hpp>
 #include <fc/string.hpp>
+#include <fc/interprocess/container.hpp>
 
 #include <iostream>
+#include <fstream>
 #include <graphene/protocol/protocol.hpp>
 #include <graphene/protocol/types.hpp>
 #include <future>
@@ -50,6 +67,8 @@ namespace chain {
 
         bool skip_virtual_ops = false;
 
+        std::string load_snapshot_path;
+
         graphene::chain::database db;
 
         bool single_write_thread = false;
@@ -83,6 +102,7 @@ namespace chain {
         void accept_transaction(const protocol::signed_transaction &trx);
         void wipe_db(const bfs::path &data_dir, bool wipe_block_log);
         void replay_db(const bfs::path &data_dir, bool force_replay);
+        bool load_from_snapshot(const bfs::path &data_dir);
     };
 
     void plugin::plugin_impl::check_time_in_block(const protocol::signed_block &block) {
@@ -144,6 +164,244 @@ namespace chain {
         ilog("Replaying blockchain from block num ${from}.", ("from", from_block_num));
         db.reindex(data_dir, shared_memory_dir, from_block_num, shared_memory_size);
     };
+
+    // Helper: remove all objects of a given type from the database
+    template<typename IndexType, typename ObjectType>
+    void clear_index(graphene::chain::database &db) {
+        const auto &idx = db.get_index<IndexType>().indices().template get<graphene::chain::by_id>();
+        std::vector<typename ObjectType::id_type> ids;
+        ids.reserve(std::distance(idx.begin(), idx.end()));
+        for (auto itr = idx.begin(); itr != idx.end(); ++itr) {
+            ids.push_back(itr->id);
+        }
+        for (const auto &id : ids) {
+            const auto &obj = db.get<ObjectType>(id);
+            db.remove(obj);
+        }
+    }
+
+    // Helper template: clear existing objects then import from snapshot payload.
+    // Uses fc::raw::unpack directly into the object created by chainbase
+    // (avoids the deleted default constructor problem).
+    //
+    // ID handling: chainbase::emplace sets id = _next_id before calling our constructor,
+    // then our constructor overwrites id with the snapshot value. The multi_index
+    // stores the object with the snapshot ID (correct), but _next_id may be wrong.
+    // After all objects are imported, we advance _next_id by creating+removing dummy
+    // objects until _next_id exceeds the max ID in the snapshot.
+    template<typename IndexType, typename ObjectType>
+    void import_snapshot_section(
+        graphene::chain::database &db,
+        const char *payload_data,
+        const graphene::plugins::snapshot::snapshot_section_info &section
+    ) {
+        // Clear any objects created by init_genesis
+        clear_index<IndexType, ObjectType>(db);
+
+        fc::datastream<const char*> ds(payload_data + section.offset, section.size);
+
+        uint64_t count;
+        fc::raw::unpack(ds, count);
+
+        ilog("Importing ${n} ${type} objects", ("n", count)("type", section.type));
+
+        typename ObjectType::id_type max_id(0);
+        for (uint64_t i = 0; i < count; i++) {
+            const auto &created = db.create<ObjectType>([&](ObjectType &obj) {
+                fc::raw::unpack(ds, obj);
+            });
+            if (created.id > max_id) {
+                max_id = created.id;
+            }
+        }
+
+        // Fix chainbase _next_id to be max_id + 1, so future creates
+        // don't collide with imported IDs.
+        if (count > 0) {
+            using index_type = typename chainbase::get_index_type<ObjectType>::type;
+            db.get_mutable_index<index_type>().set_next_id(
+                typename ObjectType::id_type(max_id._id + 1));
+        }
+    }
+
+    bool plugin::plugin_impl::load_from_snapshot(const bfs::path &data_dir) {
+        using namespace graphene::plugins::snapshot;
+        using namespace graphene::chain;
+
+        ilog("Loading state from snapshot: ${path}", ("path", load_snapshot_path));
+
+        // Read file
+        std::ifstream in(load_snapshot_path, std::ios::binary | std::ios::ate);
+        if (!in.is_open()) {
+            elog("Failed to open snapshot file: ${path}", ("path", load_snapshot_path));
+            return false;
+        }
+
+        size_t file_size = in.tellg();
+        in.seekg(0, std::ios::beg);
+
+        // Verify magic
+        char magic[8];
+        in.read(magic, 8);
+        if (std::memcmp(magic, SNAPSHOT_MAGIC, 8) != 0) {
+            elog("Invalid snapshot file: bad magic");
+            return false;
+        }
+
+        // Version
+        uint32_t version;
+        in.read(reinterpret_cast<char*>(&version), 4);
+        if (version != SNAPSHOT_FORMAT_VERSION) {
+            elog("Unsupported snapshot version: ${v}", ("v", version));
+            return false;
+        }
+
+        // Header
+        uint32_t header_len;
+        in.read(reinterpret_cast<char*>(&header_len), 4);
+        std::string header_json(header_len, '\0');
+        in.read(&header_json[0], header_len);
+
+        auto header = fc::json::from_string(header_json).as<snapshot_header>();
+
+        // Read payload
+        size_t payload_offset = 8 + 4 + 4 + header_len;
+        size_t payload_size = file_size - payload_offset;
+        std::vector<char> payload(payload_size);
+        in.read(payload.data(), payload_size);
+        in.close();
+
+        // Verify SHA256
+        auto computed_hash = fc::sha256::hash(payload.data(), payload.size());
+        if (computed_hash.str() != header.payload_sha256) {
+            elog("Snapshot SHA256 mismatch!");
+            return false;
+        }
+
+        ilog("Snapshot payload SHA256 verified: block ${b}, ${s} sections",
+            ("b", header.head_block_num)("s", header.sections.size()));
+
+        // Verify snapshot block exists in block_log and has valid signature
+        auto block = db.get_block_log().read_block_by_num(header.head_block_num);
+        if (!block) {
+            elog("Snapshot block ${b} not found in block_log. "
+                 "Block log may be truncated or snapshot is from a different chain.",
+                 ("b", header.head_block_num));
+            return false;
+        }
+
+        // Verify block ID matches
+        auto block_id = block->id();
+        if (block_id.str() != header.head_block_id) {
+            elog("Block ID mismatch at block ${b}: snapshot has ${snap}, block_log has ${log}",
+                 ("b", header.head_block_num)
+                 ("snap", header.head_block_id)
+                 ("log", block_id.str()));
+            return false;
+        }
+
+        // Verify block signature (recover public key from signature + digest)
+        try {
+            auto signee = block->signee();
+            FC_ASSERT(signee != fc::ecc::public_key(),
+                "Block ${b} has invalid signature (cannot recover public key)",
+                ("b", header.head_block_num));
+            ilog("Snapshot block ${b} signature verified (witness: ${w}, signee: ${s})",
+                ("b", header.head_block_num)("w", block->witness)
+                ("s", std::string(signee)));
+        } catch (const fc::exception &e) {
+            elog("Block ${b} signature verification failed: ${e}",
+                 ("b", header.head_block_num)("e", e.to_detail_string()));
+            return false;
+        }
+
+        // Verify chain_id matches
+        if (db.get_chain_id().str() != header.chain_id) {
+            elog("Chain ID mismatch: snapshot is for chain ${snap}, this node is ${node}",
+                 ("snap", header.chain_id)("node", db.get_chain_id().str()));
+            return false;
+        }
+
+        ilog("Snapshot integrity fully verified");
+
+        // Wipe DB and start fresh
+        wipe_db(data_dir, false);
+
+        // Import each section
+        for (const auto &section : header.sections) {
+            if (section.type == "dynamic_global_property") {
+                import_snapshot_section<dynamic_global_property_index, dynamic_global_property_object>(db, payload.data(), section);
+            } else if (section.type == "account") {
+                import_snapshot_section<account_index, account_object>(db, payload.data(), section);
+            } else if (section.type == "account_authority") {
+                import_snapshot_section<account_authority_index, account_authority_object>(db, payload.data(), section);
+            } else if (section.type == "witness") {
+                import_snapshot_section<witness_index, witness_object>(db, payload.data(), section);
+            } else if (section.type == "transaction") {
+                import_snapshot_section<transaction_index, transaction_object>(db, payload.data(), section);
+            } else if (section.type == "block_summary") {
+                import_snapshot_section<block_summary_index, block_summary_object>(db, payload.data(), section);
+            } else if (section.type == "witness_schedule") {
+                import_snapshot_section<witness_schedule_index, witness_schedule_object>(db, payload.data(), section);
+            } else if (section.type == "content") {
+                import_snapshot_section<content_index, content_object>(db, payload.data(), section);
+            } else if (section.type == "content_type") {
+                import_snapshot_section<content_type_index, content_type_object>(db, payload.data(), section);
+            } else if (section.type == "content_vote") {
+                import_snapshot_section<content_vote_index, content_vote_object>(db, payload.data(), section);
+            } else if (section.type == "witness_vote") {
+                import_snapshot_section<witness_vote_index, witness_vote_object>(db, payload.data(), section);
+            } else if (section.type == "hardfork_property") {
+                import_snapshot_section<hardfork_property_index, hardfork_property_object>(db, payload.data(), section);
+            } else if (section.type == "withdraw_vesting_route") {
+                import_snapshot_section<withdraw_vesting_route_index, withdraw_vesting_route_object>(db, payload.data(), section);
+            } else if (section.type == "master_authority_history") {
+                import_snapshot_section<master_authority_history_index, master_authority_history_object>(db, payload.data(), section);
+            } else if (section.type == "account_recovery_request") {
+                import_snapshot_section<account_recovery_request_index, account_recovery_request_object>(db, payload.data(), section);
+            } else if (section.type == "change_recovery_account_request") {
+                import_snapshot_section<change_recovery_account_request_index, change_recovery_account_request_object>(db, payload.data(), section);
+            } else if (section.type == "escrow") {
+                import_snapshot_section<escrow_index, escrow_object>(db, payload.data(), section);
+            } else if (section.type == "vesting_delegation") {
+                import_snapshot_section<vesting_delegation_index, vesting_delegation_object>(db, payload.data(), section);
+            } else if (section.type == "fix_vesting_delegation") {
+                import_snapshot_section<fix_vesting_delegation_index, fix_vesting_delegation_object>(db, payload.data(), section);
+            } else if (section.type == "vesting_delegation_expiration") {
+                import_snapshot_section<vesting_delegation_expiration_index, vesting_delegation_expiration_object>(db, payload.data(), section);
+            } else if (section.type == "account_metadata") {
+                import_snapshot_section<account_metadata_index, account_metadata_object>(db, payload.data(), section);
+            } else if (section.type == "proposal") {
+                import_snapshot_section<proposal_index, proposal_object>(db, payload.data(), section);
+            } else if (section.type == "required_approval") {
+                import_snapshot_section<required_approval_index, required_approval_object>(db, payload.data(), section);
+            } else if (section.type == "committee_request") {
+                import_snapshot_section<committee_request_index, committee_request_object>(db, payload.data(), section);
+            } else if (section.type == "committee_vote") {
+                import_snapshot_section<committee_vote_index, committee_vote_object>(db, payload.data(), section);
+            } else if (section.type == "invite") {
+                import_snapshot_section<invite_index, invite_object>(db, payload.data(), section);
+            } else if (section.type == "award_shares_expire") {
+                import_snapshot_section<award_shares_expire_index, award_shares_expire_object>(db, payload.data(), section);
+            } else if (section.type == "paid_subscription") {
+                import_snapshot_section<paid_subscription_index, paid_subscription_object>(db, payload.data(), section);
+            } else if (section.type == "paid_subscribe") {
+                import_snapshot_section<paid_subscribe_index, paid_subscribe_object>(db, payload.data(), section);
+            } else if (section.type == "witness_penalty_expire") {
+                import_snapshot_section<witness_penalty_expire_index, witness_penalty_expire_object>(db, payload.data(), section);
+            } else if (section.type == "block_post_validation") {
+                import_snapshot_section<block_post_validation_index, block_post_validation_object>(db, payload.data(), section);
+            } else {
+                wlog("Unknown snapshot section: ${type}, skipping", ("type", section.type));
+            }
+        }
+
+        // Set database revision to match snapshot block
+        db.set_revision(header.head_block_num);
+
+        ilog("Snapshot loaded successfully at block ${b}", ("b", header.head_block_num));
+        return true;
+    }
 
     void plugin::plugin_impl::accept_transaction(const protocol::signed_transaction &trx) {
         uint32_t skip = db.validate_transaction(trx, db.skip_apply_transaction);
@@ -248,6 +506,9 @@ namespace chain {
             ) (
                 "validate-database-invariants", boost::program_options::bool_switch()->default_value(false),
                 "Validate all supply invariants check out"
+            ) (
+                "load-snapshot", boost::program_options::value<std::string>()->default_value(""),
+                "load state from snapshot file instead of replaying blocks"
             );
     }
 
@@ -297,6 +558,7 @@ namespace chain {
         my->resync = options.at("resync-blockchain").as<bool>();
         my->check_locks = options.at("check-locks").as<bool>();
         my->validate_invariants = options.at("validate-database-invariants").as<bool>();
+        my->load_snapshot_path = options.at("load-snapshot").as<std::string>();
         if (options.count("flush-state-interval")) {
             my->flush_interval = options.at("flush-state-interval").as<uint32_t>();
         } else {
@@ -348,11 +610,16 @@ namespace chain {
         try {
             ilog("Opening shared memory from ${path}", ("path", my->shared_memory_dir.generic_string()));
             my->db.open(data_dir, my->shared_memory_dir, CHAIN_INIT_SUPPLY, my->shared_memory_size, chainbase::database::read_write/*, my->validate_invariants*/ );
-            auto head_block_log = my->db.get_block_log().head();
-            my->replay |= head_block_log && my->db.revision() != head_block_log->block_num();
 
-            if (my->replay) {
-                my->replay_db(data_dir, my->force_replay);
+            if (!my->load_snapshot_path.empty()) {
+                my->load_from_snapshot(data_dir);
+            } else {
+                auto head_block_log = my->db.get_block_log().head();
+                my->replay |= head_block_log && my->db.revision() != head_block_log->block_num();
+
+                if (my->replay) {
+                    my->replay_db(data_dir, my->force_replay);
+                }
             }
         } catch (const graphene::chain::database_revision_exception &) {
             if (my->replay_if_corrupted) {

--- a/plugins/snapshot/CMakeLists.txt
+++ b/plugins/snapshot/CMakeLists.txt
@@ -1,0 +1,50 @@
+set(CURRENT_TARGET snapshot)
+
+list(APPEND CURRENT_TARGET_HEADERS
+    include/graphene/plugins/snapshot/plugin.hpp
+    include/graphene/plugins/snapshot/snapshot_format.hpp
+)
+
+list(APPEND CURRENT_TARGET_SOURCES
+    plugin.cpp
+)
+
+if(BUILD_SHARED_LIBRARIES)
+    add_library(graphene_${CURRENT_TARGET} SHARED
+        ${CURRENT_TARGET_HEADERS}
+        ${CURRENT_TARGET_SOURCES}
+    )
+else()
+    add_library(graphene_${CURRENT_TARGET} STATIC
+        ${CURRENT_TARGET_HEADERS}
+        ${CURRENT_TARGET_SOURCES}
+    )
+endif()
+
+add_library(graphene::${CURRENT_TARGET} ALIAS graphene_${CURRENT_TARGET})
+
+set_property(TARGET graphene_${CURRENT_TARGET} PROPERTY EXPORT_NAME ${CURRENT_TARGET})
+
+target_link_libraries(
+    graphene_${CURRENT_TARGET}
+    graphene_chain
+    graphene_chain_plugin
+    graphene_protocol
+    appbase
+    graphene::json_rpc
+    fc
+)
+
+target_include_directories(
+    graphene_${CURRENT_TARGET}
+    PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../"
+)
+
+install(TARGETS
+    graphene_${CURRENT_TARGET}
+
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+)

--- a/plugins/snapshot/include/graphene/plugins/snapshot/chainbase_raw.hpp
+++ b/plugins/snapshot/include/graphene/plugins/snapshot/chainbase_raw.hpp
@@ -1,11 +1,16 @@
 #pragma once
 
-// fc::raw serialization support for chainbase::object_id
-// Must be included before fc/io/raw.hpp to ensure ADL finds these operators
-// when fc::raw dispatches non-reflected class types via s << v / s >> v
+// fc::raw serialization support for chainbase types (object_id, shared_string, etc.)
+//
+// fc::raw dispatches non-reflected class types via s << v / s >> v (ADL).
+// The pack/unpack overloads in fc/interprocess/container.hpp are NOT used
+// by this code path. We must provide operator<</>> in the type's namespace
+// for ADL to find them.
 
 #include <chainbase/chainbase.hpp>
+#include <fc/io/raw_fwd.hpp>
 
+// chainbase::object_id - serialize as raw int64_t
 namespace chainbase {
 
     template<typename Stream, typename T>
@@ -21,3 +26,57 @@ namespace chainbase {
     }
 
 } // namespace chainbase
+
+// boost::interprocess types - shared_string, flat_set, vector
+// These live in boost::interprocess namespace, so ADL operators go there
+namespace boost { namespace interprocess {
+
+    // shared_string (basic_string with interprocess allocator)
+    template<typename Stream, typename CharT, typename Traits, typename... A>
+    inline Stream& operator<<(Stream& s, const basic_string<CharT, Traits, A...>& v) {
+        fc::raw::pack(s, fc::unsigned_int((uint32_t)v.size()));
+        if (v.size()) {
+            s.write(v.c_str(), v.size());
+        }
+        return s;
+    }
+
+    template<typename Stream, typename CharT, typename Traits, typename... A>
+    inline Stream& operator>>(Stream& s, basic_string<CharT, Traits, A...>& v) {
+        fc::unsigned_int size;
+        fc::raw::unpack(s, size);
+        v.resize(size.value);
+        if (size.value) {
+            s.read(&v[0], size.value);
+        }
+        return s;
+    }
+
+}} // boost::interprocess
+
+// boost::container::flat_set with interprocess allocator
+namespace boost { namespace container {
+
+    template<typename Stream, typename T, typename Comp, typename... A>
+    inline Stream& operator<<(Stream& s, const flat_set<T, Comp, A...>& v) {
+        fc::raw::pack(s, fc::unsigned_int((uint32_t)v.size()));
+        for (const auto& item : v) {
+            fc::raw::pack(s, item);
+        }
+        return s;
+    }
+
+    template<typename Stream, typename T, typename Comp, typename... A>
+    inline Stream& operator>>(Stream& s, flat_set<T, Comp, A...>& v) {
+        fc::unsigned_int size;
+        fc::raw::unpack(s, size);
+        v.clear();
+        for (uint32_t i = 0; i < size.value; i++) {
+            T tmp;
+            fc::raw::unpack(s, tmp);
+            v.insert(std::move(tmp));
+        }
+        return s;
+    }
+
+}} // boost::container

--- a/plugins/snapshot/include/graphene/plugins/snapshot/chainbase_raw.hpp
+++ b/plugins/snapshot/include/graphene/plugins/snapshot/chainbase_raw.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+// fc::raw serialization support for chainbase::object_id
+// Must be included before fc/io/raw.hpp to ensure ADL finds these operators
+// when fc::raw dispatches non-reflected class types via s << v / s >> v
+
+#include <chainbase/chainbase.hpp>
+
+namespace chainbase {
+
+    template<typename Stream, typename T>
+    inline Stream& operator<<(Stream& s, const object_id<T>& id) {
+        s.write((const char*)&id._id, sizeof(id._id));
+        return s;
+    }
+
+    template<typename Stream, typename T>
+    inline Stream& operator>>(Stream& s, object_id<T>& id) {
+        s.read((char*)&id._id, sizeof(id._id));
+        return s;
+    }
+
+} // namespace chainbase

--- a/plugins/snapshot/include/graphene/plugins/snapshot/plugin.hpp
+++ b/plugins/snapshot/include/graphene/plugins/snapshot/plugin.hpp
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <string>
+#include <boost/program_options.hpp>
+#include <appbase/application.hpp>
+#include <graphene/plugins/chain/plugin.hpp>
+#include <graphene/plugins/json_rpc/utility.hpp>
+#include <graphene/plugins/json_rpc/plugin.hpp>
+#include <graphene/plugins/snapshot/snapshot_format.hpp>
+
+namespace graphene {
+namespace plugins {
+namespace snapshot {
+
+using graphene::plugins::json_rpc::msg_pack;
+
+DEFINE_API_ARGS(snapshot_export, msg_pack, snapshot_export_r)
+DEFINE_API_ARGS(snapshot_info, msg_pack, snapshot_info_r)
+DEFINE_API_ARGS(snapshot_verify, msg_pack, snapshot_verify_r)
+
+class plugin final : public appbase::plugin<plugin> {
+public:
+    APPBASE_PLUGIN_REQUIRES(
+        (chain::plugin)
+        (json_rpc::plugin)
+    )
+
+    constexpr const static char *plugin_name = "snapshot";
+
+    static const std::string &name() {
+        static std::string name = plugin_name;
+        return name;
+    }
+
+    plugin();
+
+    ~plugin();
+
+    void set_program_options(
+        boost::program_options::options_description &cli,
+        boost::program_options::options_description &cfg) override;
+
+    void plugin_initialize(const boost::program_options::variables_map &options) override;
+
+    void plugin_startup() override;
+
+    void plugin_shutdown() override;
+
+    DECLARE_API(
+        (snapshot_export)
+        (snapshot_info)
+        (snapshot_verify)
+    )
+
+private:
+    struct plugin_impl;
+    std::unique_ptr<plugin_impl> my;
+};
+
+} } } // graphene::plugins::snapshot

--- a/plugins/snapshot/include/graphene/plugins/snapshot/snapshot_format.hpp
+++ b/plugins/snapshot/include/graphene/plugins/snapshot/snapshot_format.hpp
@@ -5,24 +5,6 @@
 #include <cstdint>
 #include <fc/crypto/sha256.hpp>
 #include <fc/time.hpp>
-#include <fc/io/raw.hpp>
-#include <chainbase/chainbase.hpp>
-
-// fc::raw pack/unpack for chainbase::object_id (not reflected, needs explicit support)
-namespace fc { namespace raw {
-
-    template<typename Stream, typename T>
-    inline void pack(Stream& s, const chainbase::object_id<T>& id) {
-        fc::raw::pack(s, id._id);
-    }
-
-    template<typename Stream, typename T>
-    inline void unpack(Stream& s, chainbase::object_id<T>& id, uint32_t depth = 0) {
-        fc::raw::unpack(s, id._id, depth);
-    }
-
-}} // fc::raw
-
 namespace graphene {
 namespace plugins {
 namespace snapshot {

--- a/plugins/snapshot/include/graphene/plugins/snapshot/snapshot_format.hpp
+++ b/plugins/snapshot/include/graphene/plugins/snapshot/snapshot_format.hpp
@@ -5,6 +5,23 @@
 #include <cstdint>
 #include <fc/crypto/sha256.hpp>
 #include <fc/time.hpp>
+#include <fc/io/raw.hpp>
+#include <chainbase/chainbase.hpp>
+
+// fc::raw pack/unpack for chainbase::object_id (not reflected, needs explicit support)
+namespace fc { namespace raw {
+
+    template<typename Stream, typename T>
+    inline void pack(Stream& s, const chainbase::object_id<T>& id) {
+        fc::raw::pack(s, id._id);
+    }
+
+    template<typename Stream, typename T>
+    inline void unpack(Stream& s, chainbase::object_id<T>& id, uint32_t depth = 0) {
+        fc::raw::unpack(s, id._id, depth);
+    }
+
+}} // fc::raw
 
 namespace graphene {
 namespace plugins {

--- a/plugins/snapshot/include/graphene/plugins/snapshot/snapshot_format.hpp
+++ b/plugins/snapshot/include/graphene/plugins/snapshot/snapshot_format.hpp
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <cstdint>
+#include <fc/crypto/sha256.hpp>
+#include <fc/time.hpp>
+
+namespace graphene {
+namespace plugins {
+namespace snapshot {
+
+constexpr const char SNAPSHOT_MAGIC[8] = {'V','I','Z','S','N','A','P','\0'};
+constexpr uint32_t SNAPSHOT_FORMAT_VERSION = 1;
+
+struct snapshot_section_info {
+    std::string type;
+    uint64_t count = 0;
+    uint64_t offset = 0;
+    uint64_t size = 0;
+};
+
+struct snapshot_header {
+    std::string chain_id;
+    uint32_t head_block_num = 0;
+    std::string head_block_id;
+    std::string timestamp;
+    uint32_t snapshot_version = SNAPSHOT_FORMAT_VERSION;
+    std::vector<snapshot_section_info> sections;
+    std::string payload_sha256;
+};
+
+struct snapshot_export_r {
+    bool success = false;
+    std::string path;
+    uint32_t head_block_num = 0;
+    uint64_t total_objects = 0;
+    uint32_t sections = 0;
+    std::string sha256;
+    std::string error;
+};
+
+struct snapshot_info_r {
+    bool valid = false;
+    snapshot_header header;
+    std::string error;
+};
+
+struct snapshot_verify_r {
+    bool success = false;
+    uint64_t objects_checked = 0;
+    uint64_t objects_matched = 0;
+    uint64_t objects_mismatched = 0;
+    uint64_t objects_missing = 0;
+    std::vector<std::string> mismatches;
+    std::string error;
+};
+
+} } } // graphene::plugins::snapshot
+
+FC_REFLECT((graphene::plugins::snapshot::snapshot_section_info),
+    (type)(count)(offset)(size))
+
+FC_REFLECT((graphene::plugins::snapshot::snapshot_header),
+    (chain_id)(head_block_num)(head_block_id)(timestamp)
+    (snapshot_version)(sections)(payload_sha256))
+
+FC_REFLECT((graphene::plugins::snapshot::snapshot_export_r),
+    (success)(path)(head_block_num)(total_objects)(sections)(sha256)(error))
+
+FC_REFLECT((graphene::plugins::snapshot::snapshot_info_r),
+    (valid)(header)(error))
+
+FC_REFLECT((graphene::plugins::snapshot::snapshot_verify_r),
+    (success)(objects_checked)(objects_matched)(objects_mismatched)(objects_missing)(mismatches)(error))

--- a/plugins/snapshot/plugin.cpp
+++ b/plugins/snapshot/plugin.cpp
@@ -45,7 +45,7 @@ snapshot_section_info export_section(
     info.type = type_name;
     info.offset = payload.size();
 
-    const auto &idx = db.get_index<IndexType>().indices().template get<by_id>();
+    const auto &idx = db.get_index<IndexType>().indices();
     info.count = std::distance(idx.begin(), idx.end());
 
     // Pack count

--- a/plugins/snapshot/plugin.cpp
+++ b/plugins/snapshot/plugin.cpp
@@ -69,7 +69,9 @@ snapshot_section_info export_section(
 
 struct plugin::plugin_impl {
 public:
-    plugin_impl() : db_(appbase::app().get_plugin<plugins::chain::plugin>().db()) {
+    plugin_impl()
+        : chain_plugin_(appbase::app().get_plugin<plugins::chain::plugin>()),
+          db_(chain_plugin_.db()) {
     }
 
     snapshot_export_r do_export(const std::string &path);
@@ -85,6 +87,10 @@ public:
         return db_;
     }
 
+    plugins::chain::plugin &chain() {
+        return chain_plugin_;
+    }
+
     // Config
     uint32_t snapshot_every = 0;        // 0 = disabled
     std::string snapshot_dir;
@@ -96,6 +102,7 @@ public:
     std::atomic<bool> export_in_progress_{false};
 
 private:
+    plugins::chain::plugin &chain_plugin_;
     graphene::chain::database &db_;
 };
 
@@ -130,9 +137,15 @@ void plugin::plugin_impl::trigger_export() {
 
     try {
         auto path = generate_snapshot_path();
-        ilog("snapshot: starting export to ${path}", ("path", path));
+        ilog("snapshot: pausing chain for snapshot export to ${path}", ("path", path));
+
+        // Pause block processing before export
+        chain().pause();
 
         auto result = do_export(path);
+
+        // Resume block processing after export
+        chain().resume();
 
         if (result.success) {
             ilog("snapshot: exported ${n} objects in ${s} sections to ${path} at block ${b}",
@@ -142,6 +155,8 @@ void plugin::plugin_impl::trigger_export() {
             elog("snapshot: export failed: ${e}", ("e", result.error));
         }
     } catch (const std::exception &e) {
+        // Always resume on error
+        chain().resume();
         elog("snapshot: export exception: ${e}", ("e", e.what()));
     }
 
@@ -516,9 +531,22 @@ snapshot_verify_r plugin::plugin_impl::do_verify(const std::string &path) {
 DEFINE_API(plugin, snapshot_export) {
     auto path = args.args->at(0).as<std::string>();
     auto &db = my->database();
-    return db.with_weak_read_lock([&]() {
-        return my->do_export(path);
-    });
+
+    // Pause chain for consistent snapshot
+    my->chain().pause();
+
+    snapshot_export_r result;
+    try {
+        result = db.with_weak_read_lock([&]() {
+            return my->do_export(path);
+        });
+    } catch (...) {
+        my->chain().resume();
+        throw;
+    }
+
+    my->chain().resume();
+    return result;
 }
 
 DEFINE_API(plugin, snapshot_info) {

--- a/plugins/snapshot/plugin.cpp
+++ b/plugins/snapshot/plugin.cpp
@@ -1,3 +1,4 @@
+#include <graphene/plugins/snapshot/chainbase_raw.hpp>
 #include <graphene/plugins/snapshot/plugin.hpp>
 #include <graphene/chain/database.hpp>
 #include <graphene/chain/global_property_object.hpp>

--- a/plugins/snapshot/plugin.cpp
+++ b/plugins/snapshot/plugin.cpp
@@ -154,10 +154,15 @@ void plugin::plugin_impl::trigger_export() {
         } else {
             elog("snapshot: export failed: ${e}", ("e", result.error));
         }
+    } catch (const fc::exception &e) {
+        chain().resume();
+        elog("snapshot: export exception: ${e}", ("e", e.to_detail_string()));
     } catch (const std::exception &e) {
-        // Always resume on error
         chain().resume();
         elog("snapshot: export exception: ${e}", ("e", e.what()));
+    } catch (...) {
+        chain().resume();
+        elog("snapshot: export unknown exception");
     }
 
     export_in_progress_ = false;

--- a/plugins/snapshot/plugin.cpp
+++ b/plugins/snapshot/plugin.cpp
@@ -1,0 +1,594 @@
+#include <graphene/plugins/snapshot/plugin.hpp>
+#include <graphene/chain/database.hpp>
+#include <graphene/chain/global_property_object.hpp>
+#include <graphene/chain/account_object.hpp>
+#include <graphene/chain/witness_objects.hpp>
+#include <graphene/chain/content_object.hpp>
+#include <graphene/chain/chain_objects.hpp>
+#include <graphene/chain/proposal_object.hpp>
+#include <graphene/chain/committee_objects.hpp>
+#include <graphene/chain/invite_objects.hpp>
+#include <graphene/chain/paid_subscription_objects.hpp>
+#include <graphene/chain/block_summary_object.hpp>
+#include <graphene/chain/transaction_object.hpp>
+#include <graphene/chain/chain_object_types.hpp>
+#include <graphene/protocol/types.hpp>
+#include <graphene/plugins/json_rpc/utility.hpp>
+#include <graphene/plugins/json_rpc/plugin.hpp>
+
+#include <fc/io/fstream.hpp>
+#include <fc/io/raw.hpp>
+#include <fc/crypto/sha256.hpp>
+#include <fc/interprocess/container.hpp>
+
+#include <boost/asio/signal_set.hpp>
+
+#include <fstream>
+#include <csignal>
+#include <atomic>
+
+namespace graphene {
+namespace plugins {
+namespace snapshot {
+
+using namespace graphene::chain;
+
+// Helper: export one index section to a buffer, returning section info
+template<typename IndexType>
+snapshot_section_info export_section(
+    database &db,
+    std::vector<char> &payload,
+    const std::string &type_name
+) {
+    snapshot_section_info info;
+    info.type = type_name;
+    info.offset = payload.size();
+
+    const auto &idx = db.get_index<IndexType>().indices().template get<by_id>();
+    info.count = std::distance(idx.begin(), idx.end());
+
+    // Pack count
+    auto count_size = fc::raw::pack_size(uint64_t(info.count));
+    size_t old_size = payload.size();
+    payload.resize(old_size + count_size);
+    fc::datastream<char*> count_ds(payload.data() + old_size, count_size);
+    fc::raw::pack(count_ds, uint64_t(info.count));
+
+    // Pack each object
+    for (const auto &obj : idx) {
+        auto obj_size = fc::raw::pack_size(obj);
+        old_size = payload.size();
+        payload.resize(old_size + obj_size);
+        fc::datastream<char*> obj_ds(payload.data() + old_size, obj_size);
+        fc::raw::pack(obj_ds, obj);
+    }
+
+    info.size = payload.size() - info.offset;
+    return info;
+}
+
+struct plugin::plugin_impl {
+public:
+    plugin_impl() : db_(appbase::app().get_plugin<plugins::chain::plugin>().db()) {
+    }
+
+    snapshot_export_r do_export(const std::string &path);
+    snapshot_info_r do_info(const std::string &path);
+    snapshot_verify_r do_verify(const std::string &path);
+
+    void on_applied_block(const protocol::signed_block &b);
+    void trigger_export();
+    std::string generate_snapshot_path();
+    void register_sigusr1_handler();
+
+    graphene::chain::database &database() {
+        return db_;
+    }
+
+    // Config
+    uint32_t snapshot_every = 0;        // 0 = disabled
+    std::string snapshot_dir;
+
+    // State
+    boost::signals2::scoped_connection applied_block_conn_;
+    std::shared_ptr<boost::asio::signal_set> sigusr1_set_;
+    std::atomic<bool> export_requested_{false};
+    std::atomic<bool> export_in_progress_{false};
+
+private:
+    graphene::chain::database &db_;
+};
+
+std::string plugin::plugin_impl::generate_snapshot_path() {
+    auto &db = database();
+    const auto &dgpo = db.get_dynamic_global_properties();
+    std::string filename = "snapshot-block-" + std::to_string(dgpo.head_block_number) + ".bin";
+    if (snapshot_dir.empty()) {
+        return (appbase::app().data_dir() / filename).string();
+    }
+    boost::filesystem::path dir(snapshot_dir);
+    if (!boost::filesystem::exists(dir)) {
+        boost::filesystem::create_directories(dir);
+    }
+    return (dir / filename).string();
+}
+
+void plugin::plugin_impl::register_sigusr1_handler() {
+    sigusr1_set_->async_wait([this](const boost::system::error_code &err, int) {
+        if (err) return;
+        ilog("snapshot: SIGUSR1 received, scheduling export on next block");
+        export_requested_ = true;
+        register_sigusr1_handler(); // re-register for next signal
+    });
+}
+
+void plugin::plugin_impl::trigger_export() {
+    if (export_in_progress_.exchange(true)) {
+        ilog("snapshot: export already in progress, skipping");
+        return;
+    }
+
+    try {
+        auto path = generate_snapshot_path();
+        ilog("snapshot: starting export to ${path}", ("path", path));
+
+        auto result = do_export(path);
+
+        if (result.success) {
+            ilog("snapshot: exported ${n} objects in ${s} sections to ${path} at block ${b}",
+                ("n", result.total_objects)("s", result.sections)
+                ("path", result.path)("b", result.head_block_num));
+        } else {
+            elog("snapshot: export failed: ${e}", ("e", result.error));
+        }
+    } catch (const std::exception &e) {
+        elog("snapshot: export exception: ${e}", ("e", e.what()));
+    }
+
+    export_in_progress_ = false;
+}
+
+void plugin::plugin_impl::on_applied_block(const protocol::signed_block &b) {
+    // Check signal-triggered export
+    if (export_requested_.exchange(false)) {
+        trigger_export();
+        return;
+    }
+
+    // Check interval-based export
+    if (snapshot_every > 0) {
+        uint32_t block_num = b.block_num();
+        if (block_num % snapshot_every == 0) {
+            trigger_export();
+        }
+    }
+}
+
+snapshot_export_r plugin::plugin_impl::do_export(const std::string &path) {
+    snapshot_export_r result;
+    try {
+        auto &db = database();
+
+        // Build payload with all sections
+        std::vector<char> payload;
+        payload.reserve(64 * 1024 * 1024); // pre-allocate 64MB
+
+        std::vector<snapshot_section_info> sections;
+
+        // Export all core indexes in initialize_indexes() order
+        sections.push_back(export_section<dynamic_global_property_index>(db, payload, "dynamic_global_property"));
+        sections.push_back(export_section<account_index>(db, payload, "account"));
+        sections.push_back(export_section<account_authority_index>(db, payload, "account_authority"));
+        sections.push_back(export_section<witness_index>(db, payload, "witness"));
+        sections.push_back(export_section<transaction_index>(db, payload, "transaction"));
+        sections.push_back(export_section<block_summary_index>(db, payload, "block_summary"));
+        sections.push_back(export_section<witness_schedule_index>(db, payload, "witness_schedule"));
+        sections.push_back(export_section<content_index>(db, payload, "content"));
+        sections.push_back(export_section<content_type_index>(db, payload, "content_type"));
+        sections.push_back(export_section<content_vote_index>(db, payload, "content_vote"));
+        sections.push_back(export_section<witness_vote_index>(db, payload, "witness_vote"));
+        sections.push_back(export_section<hardfork_property_index>(db, payload, "hardfork_property"));
+        sections.push_back(export_section<withdraw_vesting_route_index>(db, payload, "withdraw_vesting_route"));
+        sections.push_back(export_section<master_authority_history_index>(db, payload, "master_authority_history"));
+        sections.push_back(export_section<account_recovery_request_index>(db, payload, "account_recovery_request"));
+        sections.push_back(export_section<change_recovery_account_request_index>(db, payload, "change_recovery_account_request"));
+        sections.push_back(export_section<escrow_index>(db, payload, "escrow"));
+        sections.push_back(export_section<vesting_delegation_index>(db, payload, "vesting_delegation"));
+        sections.push_back(export_section<fix_vesting_delegation_index>(db, payload, "fix_vesting_delegation"));
+        sections.push_back(export_section<vesting_delegation_expiration_index>(db, payload, "vesting_delegation_expiration"));
+        sections.push_back(export_section<account_metadata_index>(db, payload, "account_metadata"));
+        sections.push_back(export_section<proposal_index>(db, payload, "proposal"));
+        sections.push_back(export_section<required_approval_index>(db, payload, "required_approval"));
+        sections.push_back(export_section<committee_request_index>(db, payload, "committee_request"));
+        sections.push_back(export_section<committee_vote_index>(db, payload, "committee_vote"));
+        sections.push_back(export_section<invite_index>(db, payload, "invite"));
+        sections.push_back(export_section<award_shares_expire_index>(db, payload, "award_shares_expire"));
+        sections.push_back(export_section<paid_subscription_index>(db, payload, "paid_subscription"));
+        sections.push_back(export_section<paid_subscribe_index>(db, payload, "paid_subscribe"));
+        sections.push_back(export_section<witness_penalty_expire_index>(db, payload, "witness_penalty_expire"));
+        sections.push_back(export_section<block_post_validation_index>(db, payload, "block_post_validation"));
+
+        // Compute SHA256 of payload
+        auto payload_hash = fc::sha256::hash(payload.data(), payload.size());
+
+        // Build header
+        const auto &dgpo = db.get_dynamic_global_properties();
+        snapshot_header header;
+        header.chain_id = db.get_chain_id().str();
+        header.head_block_num = dgpo.head_block_number;
+        header.head_block_id = dgpo.head_block_id.str();
+        header.timestamp = dgpo.time.to_iso_string();
+        header.snapshot_version = SNAPSHOT_FORMAT_VERSION;
+        header.sections = sections;
+        header.payload_sha256 = payload_hash.str();
+
+        std::string header_json = fc::json::to_string(header);
+
+        // Write file
+        std::ofstream out(path, std::ios::binary);
+        if (!out.is_open()) {
+            result.error = "Failed to open file: " + path;
+            return result;
+        }
+
+        // Magic
+        out.write(SNAPSHOT_MAGIC, 8);
+
+        // Format version
+        uint32_t version = SNAPSHOT_FORMAT_VERSION;
+        out.write(reinterpret_cast<const char*>(&version), 4);
+
+        // Header length
+        uint32_t header_len = header_json.size();
+        out.write(reinterpret_cast<const char*>(&header_len), 4);
+
+        // Header JSON
+        out.write(header_json.c_str(), header_json.size());
+
+        // Payload
+        out.write(payload.data(), payload.size());
+
+        out.close();
+
+        // Build result
+        result.success = true;
+        result.path = path;
+        result.head_block_num = dgpo.head_block_number;
+        result.sha256 = payload_hash.str();
+        result.sections = sections.size();
+        result.total_objects = 0;
+        for (const auto &s : sections) {
+            result.total_objects += s.count;
+        }
+    } catch (const fc::exception &e) {
+        result.error = e.to_detail_string();
+    } catch (const std::exception &e) {
+        result.error = e.what();
+    }
+    return result;
+}
+
+snapshot_info_r plugin::plugin_impl::do_info(const std::string &path) {
+    snapshot_info_r result;
+    try {
+        std::ifstream in(path, std::ios::binary);
+        if (!in.is_open()) {
+            result.error = "Failed to open file: " + path;
+            return result;
+        }
+
+        // Read and verify magic
+        char magic[8];
+        in.read(magic, 8);
+        if (std::memcmp(magic, SNAPSHOT_MAGIC, 8) != 0) {
+            result.error = "Invalid snapshot file: bad magic";
+            return result;
+        }
+
+        // Read version
+        uint32_t version;
+        in.read(reinterpret_cast<char*>(&version), 4);
+        if (version != SNAPSHOT_FORMAT_VERSION) {
+            result.error = "Unsupported snapshot version: " + std::to_string(version);
+            return result;
+        }
+
+        // Read header length
+        uint32_t header_len;
+        in.read(reinterpret_cast<char*>(&header_len), 4);
+
+        // Read header JSON
+        std::string header_json(header_len, '\0');
+        in.read(&header_json[0], header_len);
+
+        result.header = fc::json::from_string(header_json).as<snapshot_header>();
+        result.valid = true;
+    } catch (const fc::exception &e) {
+        result.error = e.to_detail_string();
+    } catch (const std::exception &e) {
+        result.error = e.what();
+    }
+    return result;
+}
+
+// Verify a section by re-exporting from DB and comparing bytes.
+// This avoids constructing temporary objects (many have deleted default constructors).
+template<typename IndexType>
+void verify_section(
+    database &db,
+    const char *payload_data,
+    const snapshot_section_info &section,
+    snapshot_verify_r &result
+) {
+    // Re-export this section from DB
+    std::vector<char> db_payload;
+    auto db_section = export_section<IndexType>(db, db_payload, section.type);
+
+    result.objects_checked += section.count;
+
+    if (db_section.count != section.count) {
+        result.objects_mismatched += section.count;
+        result.mismatches.push_back(section.type + ": snapshot has " +
+            std::to_string(section.count) + " objects, DB has " +
+            std::to_string(db_section.count));
+        return;
+    }
+
+    if (db_section.size != section.size) {
+        result.objects_mismatched += section.count;
+        result.mismatches.push_back(section.type + ": byte size mismatch (snapshot=" +
+            std::to_string(section.size) + ", DB=" + std::to_string(db_section.size) + ")");
+        return;
+    }
+
+    // Compare raw bytes
+    if (std::memcmp(payload_data + section.offset, db_payload.data(), section.size) == 0) {
+        result.objects_matched += section.count;
+    } else {
+        result.objects_mismatched += section.count;
+        result.mismatches.push_back(section.type + ": binary data mismatch");
+    }
+}
+
+snapshot_verify_r plugin::plugin_impl::do_verify(const std::string &path) {
+    snapshot_verify_r result;
+    try {
+        // Read entire file
+        std::ifstream in(path, std::ios::binary | std::ios::ate);
+        if (!in.is_open()) {
+            result.error = "Failed to open file: " + path;
+            return result;
+        }
+
+        size_t file_size = in.tellg();
+        in.seekg(0, std::ios::beg);
+
+        // Verify magic
+        char magic[8];
+        in.read(magic, 8);
+        if (std::memcmp(magic, SNAPSHOT_MAGIC, 8) != 0) {
+            result.error = "Invalid snapshot file: bad magic";
+            return result;
+        }
+
+        // Read version
+        uint32_t version;
+        in.read(reinterpret_cast<char*>(&version), 4);
+
+        // Read header
+        uint32_t header_len;
+        in.read(reinterpret_cast<char*>(&header_len), 4);
+        std::string header_json(header_len, '\0');
+        in.read(&header_json[0], header_len);
+
+        auto header = fc::json::from_string(header_json).as<snapshot_header>();
+
+        // Read payload
+        size_t payload_offset = 8 + 4 + 4 + header_len;
+        size_t payload_size = file_size - payload_offset;
+        std::vector<char> payload(payload_size);
+        in.read(payload.data(), payload_size);
+        in.close();
+
+        // Verify SHA256
+        auto computed_hash = fc::sha256::hash(payload.data(), payload.size());
+        if (computed_hash.str() != header.payload_sha256) {
+            result.error = "SHA256 mismatch: expected " + header.payload_sha256 +
+                ", got " + computed_hash.str();
+            return result;
+        }
+
+        auto &db = database();
+
+        // Verify block signature from block_log
+        auto block = db.get_block_log().read_block_by_num(header.head_block_num);
+        if (!block) {
+            result.error = "Block " + std::to_string(header.head_block_num) +
+                " not found in block_log";
+            return result;
+        }
+
+        if (block->id().str() != header.head_block_id) {
+            result.error = "Block ID mismatch at block " +
+                std::to_string(header.head_block_num) +
+                ": snapshot=" + header.head_block_id +
+                ", block_log=" + block->id().str();
+            return result;
+        }
+
+        try {
+            auto signee = block->signee();
+            if (signee == fc::ecc::public_key()) {
+                result.error = "Block " + std::to_string(header.head_block_num) +
+                    " has invalid signature";
+                return result;
+            }
+        } catch (...) {
+            result.error = "Block signature verification failed for block " +
+                std::to_string(header.head_block_num);
+            return result;
+        }
+
+        if (db.get_chain_id().str() != header.chain_id) {
+            result.error = "Chain ID mismatch: snapshot=" + header.chain_id +
+                ", node=" + db.get_chain_id().str();
+            return result;
+        }
+
+        // Verify each section by re-exporting from DB and comparing bytes
+        for (const auto &section : header.sections) {
+            if (section.type == "dynamic_global_property") {
+                verify_section<dynamic_global_property_index>(db, payload.data(), section, result);
+            } else if (section.type == "account") {
+                verify_section<account_index>(db, payload.data(), section, result);
+            } else if (section.type == "account_authority") {
+                verify_section<account_authority_index>(db, payload.data(), section, result);
+            } else if (section.type == "witness") {
+                verify_section<witness_index>(db, payload.data(), section, result);
+            } else if (section.type == "transaction") {
+                verify_section<transaction_index>(db, payload.data(), section, result);
+            } else if (section.type == "block_summary") {
+                verify_section<block_summary_index>(db, payload.data(), section, result);
+            } else if (section.type == "witness_schedule") {
+                verify_section<witness_schedule_index>(db, payload.data(), section, result);
+            } else if (section.type == "content") {
+                verify_section<content_index>(db, payload.data(), section, result);
+            } else if (section.type == "content_type") {
+                verify_section<content_type_index>(db, payload.data(), section, result);
+            } else if (section.type == "content_vote") {
+                verify_section<content_vote_index>(db, payload.data(), section, result);
+            } else if (section.type == "witness_vote") {
+                verify_section<witness_vote_index>(db, payload.data(), section, result);
+            } else if (section.type == "hardfork_property") {
+                verify_section<hardfork_property_index>(db, payload.data(), section, result);
+            } else if (section.type == "withdraw_vesting_route") {
+                verify_section<withdraw_vesting_route_index>(db, payload.data(), section, result);
+            } else if (section.type == "master_authority_history") {
+                verify_section<master_authority_history_index>(db, payload.data(), section, result);
+            } else if (section.type == "account_recovery_request") {
+                verify_section<account_recovery_request_index>(db, payload.data(), section, result);
+            } else if (section.type == "change_recovery_account_request") {
+                verify_section<change_recovery_account_request_index>(db, payload.data(), section, result);
+            } else if (section.type == "escrow") {
+                verify_section<escrow_index>(db, payload.data(), section, result);
+            } else if (section.type == "vesting_delegation") {
+                verify_section<vesting_delegation_index>(db, payload.data(), section, result);
+            } else if (section.type == "fix_vesting_delegation") {
+                verify_section<fix_vesting_delegation_index>(db, payload.data(), section, result);
+            } else if (section.type == "vesting_delegation_expiration") {
+                verify_section<vesting_delegation_expiration_index>(db, payload.data(), section, result);
+            } else if (section.type == "account_metadata") {
+                verify_section<account_metadata_index>(db, payload.data(), section, result);
+            } else if (section.type == "proposal") {
+                verify_section<proposal_index>(db, payload.data(), section, result);
+            } else if (section.type == "required_approval") {
+                verify_section<required_approval_index>(db, payload.data(), section, result);
+            } else if (section.type == "committee_request") {
+                verify_section<committee_request_index>(db, payload.data(), section, result);
+            } else if (section.type == "committee_vote") {
+                verify_section<committee_vote_index>(db, payload.data(), section, result);
+            } else if (section.type == "invite") {
+                verify_section<invite_index>(db, payload.data(), section, result);
+            } else if (section.type == "award_shares_expire") {
+                verify_section<award_shares_expire_index>(db, payload.data(), section, result);
+            } else if (section.type == "paid_subscription") {
+                verify_section<paid_subscription_index>(db, payload.data(), section, result);
+            } else if (section.type == "paid_subscribe") {
+                verify_section<paid_subscribe_index>(db, payload.data(), section, result);
+            } else if (section.type == "witness_penalty_expire") {
+                verify_section<witness_penalty_expire_index>(db, payload.data(), section, result);
+            } else if (section.type == "block_post_validation") {
+                verify_section<block_post_validation_index>(db, payload.data(), section, result);
+            } else {
+                result.mismatches.push_back("Unknown section type: " + section.type);
+            }
+        }
+
+        result.success = (result.objects_mismatched == 0 && result.objects_missing == 0);
+    } catch (const fc::exception &e) {
+        result.error = e.to_detail_string();
+    } catch (const std::exception &e) {
+        result.error = e.what();
+    }
+    return result;
+}
+
+DEFINE_API(plugin, snapshot_export) {
+    auto path = args.args->at(0).as<std::string>();
+    auto &db = my->database();
+    return db.with_weak_read_lock([&]() {
+        return my->do_export(path);
+    });
+}
+
+DEFINE_API(plugin, snapshot_info) {
+    auto path = args.args->at(0).as<std::string>();
+    return my->do_info(path);
+}
+
+DEFINE_API(plugin, snapshot_verify) {
+    auto path = args.args->at(0).as<std::string>();
+    auto &db = my->database();
+    return db.with_weak_read_lock([&]() {
+        return my->do_verify(path);
+    });
+}
+
+plugin::plugin() {
+}
+
+plugin::~plugin() {
+}
+
+void plugin::set_program_options(
+    boost::program_options::options_description &cli,
+    boost::program_options::options_description &cfg
+) {
+    cfg.add_options()
+        (
+            "snapshot-every", boost::program_options::value<uint32_t>()->default_value(0),
+            "automatically export snapshot every N blocks (0 = disabled)"
+        ) (
+            "snapshot-dir", boost::program_options::value<std::string>()->default_value(""),
+            "directory for automatic snapshots (default: data_dir)"
+        );
+}
+
+void plugin::plugin_initialize(const boost::program_options::variables_map &options) {
+    my.reset(new plugin_impl);
+    JSON_RPC_REGISTER_API(name());
+
+    my->snapshot_every = options.at("snapshot-every").as<uint32_t>();
+    my->snapshot_dir = options.at("snapshot-dir").as<std::string>();
+}
+
+void plugin::plugin_startup() {
+    auto &db = my->database();
+
+    // Subscribe to applied_block for interval-based and signal-triggered export
+    if (my->snapshot_every > 0 || true /* always listen for SIGUSR1 */) {
+        my->applied_block_conn_ = db.applied_block.connect([this](const protocol::signed_block &b) {
+            my->on_applied_block(b);
+        });
+    }
+
+    // Register SIGUSR1 handler for manual snapshot trigger
+    my->sigusr1_set_.reset(new boost::asio::signal_set(appbase::app().get_io_service(), SIGUSR1));
+    my->register_sigusr1_handler();
+
+    if (my->snapshot_every > 0) {
+        ilog("snapshot plugin: started, auto-export every ${n} blocks to ${d}",
+            ("n", my->snapshot_every)
+            ("d", my->snapshot_dir.empty() ? "data_dir" : my->snapshot_dir));
+    } else {
+        ilog("snapshot plugin: started (SIGUSR1 for manual export)");
+    }
+}
+
+void plugin::plugin_shutdown() {
+    if (my->sigusr1_set_) {
+        my->sigusr1_set_->cancel();
+    }
+}
+
+} } } // graphene::plugins::snapshot

--- a/plugins/witness/witness.cpp
+++ b/plugins/witness/witness.cpp
@@ -277,6 +277,12 @@ namespace graphene {
 
             block_production_condition::block_production_condition_enum witness_plugin::impl::maybe_produce_block(fc::mutable_variant_object &capture) {
                 auto &db = database();
+
+                // Do not produce blocks while database is paused (snapshot in progress)
+                if (db.is_paused()) {
+                    return block_production_condition::not_time_yet;
+                }
+
                 fc::time_point now_fine = graphene::time::now();
                 fc::time_point_sec now = now_fine + fc::microseconds( 500000 );
 

--- a/programs/vizd/CMakeLists.txt
+++ b/programs/vizd/CMakeLists.txt
@@ -41,6 +41,7 @@ target_link_libraries(
         graphene::invite_api
         graphene::paid_subscription_api
         graphene::custom_protocol_api
+        graphene::snapshot
         ${MONGO_LIB}
         graphene_protocol
         fc

--- a/programs/vizd/main.cpp
+++ b/programs/vizd/main.cpp
@@ -28,6 +28,7 @@
 #include <graphene/plugins/invite_api/invite_api.hpp>
 #include <graphene/plugins/paid_subscription_api/paid_subscription_api.hpp>
 #include <graphene/plugins/custom_protocol_api/custom_protocol_api.hpp>
+#include <graphene/plugins/snapshot/plugin.hpp>
 
 #include <fc/interprocess/signals.hpp>
 #include <fc/log/console_appender.hpp>
@@ -86,6 +87,7 @@ namespace graphene {
             appbase::app().register_plugin<graphene::plugins::invite_api::invite_api>();
             appbase::app().register_plugin<graphene::plugins::paid_subscription_api::paid_subscription_api>();
             appbase::app().register_plugin<graphene::plugins::custom_protocol_api::custom_protocol_api_plugin>();
+            appbase::app().register_plugin<graphene::plugins::snapshot::plugin>();
             ///plugins
         };
     }

--- a/share/vizd/config/config.ini
+++ b/share/vizd/config/config.ini
@@ -14,10 +14,13 @@ p2p-endpoint = 0.0.0.0:4243
 webserver-thread-pool-size = 2
 
 # IP:PORT for HTTP connections
-webserver-http-endpoint = 0.0.0.0:8090
+# SECURITY: If snapshot or other management plugins are enabled, bind to 127.0.0.1
+# to prevent external access to privileged API methods (snapshot_export, etc.)
+# Use 0.0.0.0 only for public read-only API nodes without management plugins.
+webserver-http-endpoint = 127.0.0.1:8090
 
 # IP:PORT for WebSocket connections
-webserver-ws-endpoint = 0.0.0.0:8091
+webserver-ws-endpoint = 127.0.0.1:8091
 
 # Maximum microseconds for trying to get read lock
 read-wait-micro = 500000
@@ -97,10 +100,17 @@ follow-max-feed-size = 500
 # pm-account-range =
 
 # Automatically export snapshot every N blocks (0 = disabled, 28800 = ~1 day)
+# During snapshot export the node pauses block processing (production and acceptance),
+# so set the interval high enough to avoid frequent pauses.
+# Manual export via SIGUSR1: kill -USR1 <pid>
 # snapshot-every = 0
 
 # Directory for snapshot files (default: data_dir)
 # snapshot-dir =
+
+# NOTE: Snapshot API methods (snapshot_export, snapshot_info, snapshot_verify) are
+# available via JSON-RPC. Ensure webserver endpoints are bound to 127.0.0.1
+# to prevent unauthorized external access to these management operations.
 
 # Enable block production, even if the chain is stale.
 enable-stale-production = false

--- a/share/vizd/config/config.ini
+++ b/share/vizd/config/config.ini
@@ -70,7 +70,7 @@ plugin = witness_api
 plugin = chain p2p json_rpc webserver network_broadcast_api database_api
 plugin = account_history operation_history
 plugin = committee_api invite_api paid_subscription_api custom_protocol_api
-plugin = account_by_key block_info raw_block
+plugin = account_by_key block_info raw_block snapshot
 
 # Remove votes before defined block, should increase performance
 clear-votes-before-block = 0 # clear votes after each cashout
@@ -95,6 +95,12 @@ follow-max-feed-size = 500
 
 # Defines a range of accounts to private messages to/from as a json pair ["from","to"] [from,to)
 # pm-account-range =
+
+# Automatically export snapshot every N blocks (0 = disabled, 28800 = ~1 day)
+# snapshot-every = 0
+
+# Directory for snapshot files (default: data_dir)
+# snapshot-dir =
 
 # Enable block production, even if the chain is stale.
 enable-stale-production = false


### PR DESCRIPTION
## Summary

Плагин `snapshot` для быстрого восстановления witness-нод без многочасового replay.

Проблема из чата сообщества: при падении ноды с ~20 делегатами (одна точка отказа) сеть форкается, а восстановление через replay с блока 1 (~79M блоков) занимает часы. За это время сеть может полностью остановиться.

Snapshot позволяет стартовать ноду за секунды из файла с полным состоянием chainbase.

## Что реализовано

### Новый плагин `snapshot`

**3 JSON-RPC API метода:**
- `snapshot.snapshot_export(path)` — экспорт полного состояния (31 тип chainbase-объектов) в бинарный файл
- `snapshot.snapshot_info(path)` — чтение заголовка snapshot без загрузки
- `snapshot.snapshot_verify(path)` — побайтная верификация snapshot vs текущего состояния DB

**Автоматический экспорт:**
- `--snapshot-every N` — автоэкспорт каждые N блоков (например 28800 = ~1 день)
- `--snapshot-dir /path` — директория для snapshot-файлов
- `kill -SIGUSR1 $(pidof vizd)` — ручной экспорт по сигналу

**Импорт (CLI в chain plugin):**
- `--load-snapshot /path/to/file` — загрузка состояния вместо replay при старте

### Pause/unpause при экспорте

По замечанию Анатолия — при создании снепшота нода приостанавливает обработку:
- **database.hpp**: атомарный флаг `_paused` с `is_paused()`/`set_paused()`
- **chain plugin**: `pause()`/`resume()`, блоки отклоняются и транзакции не принимаются
- **witness plugin**: не генерирует блоки пока `is_paused()`
- **snapshot plugin**: автоматически pause → export → resume с гарантией resume при любых ошибках (catch fc::exception, std::exception, ...)

### Безопасность API

Snapshot API содержит привилегированные операции (экспорт файлов на диск). В config.ini endpoints по умолчанию привязаны к `127.0.0.1` с комментарием о безопасности.

### Верификация целостности

При импорте и верификации проверяется:
1. SHA256 хеш payload
2. Блок из snapshot существует в block_log
3. Block ID совпадает
4. Подпись блока валидна (восстановление публичного ключа из ECDSA-подписи)
5. Chain ID совпадает (защита от подмены snapshot чужой сети)

### Формат файла

```
[8 bytes]  Magic: "VIZSNAP\0"
[4 bytes]  Версия формата (uint32_t = 1)
[4 bytes]  Длина JSON-заголовка
[N bytes]  JSON-заголовок (chain_id, block_num, block_id, timestamp, SHA256, секции)
[M bytes]  Binary payload (fc::raw::pack для каждого типа объектов)
```

### Сериализация chainbase типов

Для корректной сериализации/десериализации объектов chainbase добавлены:
- `chainbase_raw.hpp` — ADL-операторы `operator<<`/`operator>>` для `chainbase::object_id`, `boost::interprocess::basic_string` (shared_string), `boost::container::flat_set` с interprocess allocator
- Используется ADL (Argument-Dependent Lookup) — fc::raw вызывает `s << v` / `s >> v` для нерефлектированных классов, операторы находятся через ADL в namespace типа

### Изменения в submodules

**thirdparty/chainbase** (ветка `feat/snapshot-set-next-id` в web3blind/chainbase):
- `include/chainbase/chainbase.hpp`: добавлен метод `set_next_id()` в `generic_index` — без этого после импорта snapshot auto-increment ID может выдать уже занятый ID

## Протестировано

Собрано и протестировано в Docker (Dockerfile-production, `make -j2`, Ubuntu 18.04 / Boost 1.65):

| Тест | Результат |
|------|-----------|
| Docker build | 100%, 0 ошибок |
| Запуск ноды | Все плагины стартовали, snapshot plugin: started |
| `snapshot_export` | 65555 объектов, 31 секция, SHA256 корректен |
| Pause/Resume | `Database processing PAUSED` → `RESUMED` в логах |
| `snapshot_info` | Заголовок с chain_id, секциями, payload_sha256 |
| `snapshot_verify` | Корректная ошибка на genesis (block 0 нет в block_log) |
| Файл снепшота | 1.8MB (genesis state) |
| Регрессия | Нода без snapshot работает как обычно |

## Конфигурация

```ini
# в config.ini
plugin = snapshot

# Автоэкспорт каждые 28800 блоков (~1 день)
snapshot-every = 28800
snapshot-dir = /data/snapshots
```

Старт из snapshot:
```bash
vizd --load-snapshot /data/snapshots/snapshot-block-79105844.bin
```

Ручной экспорт:
```bash
kill -SIGUSR1 $(pidof vizd)
```

## Test plan

- [x] Скомпилировать в docker-окружении проекта (Dockerfile-production)
- [x] Запустить ноду, вызвать `snapshot_export` — файл создаётся
- [x] Проверить файл через `snapshot_info` — заголовок корректен
- [x] Проверить pause/resume в логах при экспорте
- [ ] Дождаться синхронизации, вызвать `snapshot_verify` — все секции совпадают
- [ ] Запустить вторую ноду с `--load-snapshot` — стартует без replay
- [ ] Проверить `--snapshot-every` — файлы создаются автоматически
- [ ] Проверить `kill -SIGUSR1` — экспорт по сигналу

🤖 Generated with [Claude Code](https://claude.com/claude-code)