### PR TITLE
ci: notify docs.viz.cx mirror on docs/ changes

### DIFF
--- a/.github/workflows/notify-docs-mirror.yml
+++ b/.github/workflows/notify-docs-mirror.yml
@@ -15,7 +15,7 @@ jobs:
   dispatch:
     runs-on: ubuntu-latest
     steps:
-      - uses: peter-evans/repository-dispatch@v3
+      - uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.DOCS_MIRROR_PAT }}
           repository: viz-cx/docs.viz.cx

--- a/.github/workflows/notify-docs-mirror.yml
+++ b/.github/workflows/notify-docs-mirror.yml
@@ -1,0 +1,24 @@
+name: Notify docs.viz.cx mirror
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'docs/**'
+      - '@l10n/**'
+      - 'scripts/sync-l10n.mjs'
+      - 'package.json'
+      - 'package-lock.json'
+  workflow_dispatch:
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.DOCS_MIRROR_PAT }}
+          repository: viz-cx/docs.viz.cx
+          event-type: docs-updated
+          client-payload: |
+            {"sha": "${{ github.sha }}", "ref": "${{ github.ref }}"}


### PR DESCRIPTION
Adds a workflow that fires a `repository_dispatch` event to `viz-cx/docs.viz.cx` whenever doc-relevant files change on `master`. Combined with the build pipeline in that repo, this keeps https://docs.viz.cx in sync with this repository's docs automatically.

Trigger paths match the existing `docs.yml` workflow's trigger set (`docs/**`, `@l10n/**`, `scripts/sync-l10n.mjs`, `package.json`, `package-lock.json`) so the mirror fires on the same conditions as the upstream Pages deploy.

Requires repo secret `DOCS_MIRROR_PAT` (fine-grained PAT, contents:read + actions:write on `viz-cx/docs.viz.cx`) — already configured.