### PR TITLE
fix(database): abort fork switch when pop_block() makes no progress (write-lock deadlock)

### DIFF
--- a/libraries/chain/database.cpp
+++ b/libraries/chain/database.cpp
@@ -2068,7 +2068,23 @@ namespace graphene { namespace chain {
                                          ("h", head_block_num())
                                          ("t", branches.second.back()->data.previous)
                                          ("b", branches.second.back()->data.block_num()));
+                                    block_id_type _pop_prev_id = head_block_id();
                                     pop_block();
+                                    if (head_block_id() == _pop_prev_id) {
+                                        // pop_block() made no progress: undo() had nothing to revert
+                                        // (committed/empty undo session) while head is still above LIB, so
+                                        // head_block_id() never changes and head_block_num() never reaches the
+                                        // LIB guard above. Without this check the loop spins forever holding
+                                        // the global chainbase write lock, wedging every reader and block
+                                        // production (observed: writer_held_ms climbing for hours during a
+                                        // minority-fork reorg). Abort the fork switch to release the lock.
+                                        wlog("Fork switch: pop_block() made no progress at head #${h} "
+                                             "(committed/empty undo session). Aborting fork switch to release the write lock.",
+                                             ("h", head_block_num()));
+                                        _fork_db.remove(new_head->data.id());
+                                        FC_THROW_EXCEPTION(unlinkable_block_exception,
+                                            "fork switch aborted: pop_block() made no progress (undo no-op above LIB)");
+                                    }
                                 }
                             }
 
@@ -2135,7 +2151,16 @@ namespace graphene { namespace chain {
                                             }
                                             ilog("FORK-RECOVER-POP: popping head #${h} (restoring to common ancestor)",
                                                  ("h", head_block_num()));
+                                            block_id_type _pop_prev_id = head_block_id();
                                             pop_block();
+                                            if (head_block_id() == _pop_prev_id) {
+                                                // pop_block() made no progress (committed/empty undo session while
+                                                // head is above LIB). Stop instead of spinning forever under the
+                                                // global write lock.
+                                                wlog("Fork recovery: pop_block() made no progress at head #${h}. Stopping.",
+                                                     ("h", head_block_num()));
+                                                break;
+                                            }
                                         }
                                         _fork_db.set_head(branches.second.back());
                                         wlog("Linear extension failed. Restored head to #${h}.",
@@ -2153,7 +2178,16 @@ namespace graphene { namespace chain {
                                             }
                                             ilog("FORK-RECOVER-POP: popping head #${h} (target=${t})",
                                                  ("h", head_block_num())("t", branches.second.back()->data.previous));
+                                            block_id_type _pop_prev_id = head_block_id();
                                             pop_block();
+                                            if (head_block_id() == _pop_prev_id) {
+                                                // pop_block() made no progress (committed/empty undo session while
+                                                // head is above LIB). Stop instead of spinning forever under the
+                                                // global write lock.
+                                                wlog("Fork recovery: pop_block() made no progress at head #${h}. Stopping.",
+                                                     ("h", head_block_num()));
+                                                break;
+                                            }
                                         }
 
                                         for (auto ritr2 = branches.second.rbegin();


### PR DESCRIPTION
A minority-fork node attempting to reorg onto the majority chain could wedge: push_block() holds the global chainbase write lock and never releases it (observed writer_held_ms climbing for hours), timing out every reader and blocking the validator's own block production.

Root cause: the three fork-switch pop loops in _push_block() only break when head_block_num() <= last_irreversible_block_num. pop_block() reverts head via undo(); if undo() has nothing to revert (committed/empty undo session) while head is still ABOVE LIB, head_block_id() never changes and head_block_num() never decreases to reach the LIB guard. The loop spins forever holding the write lock.

Fix: after each pop_block(), detect that head_block_id() did not change and abort the loop (main switch: remove the new head from fork_db and throw unlinkable_block_exception so the P2P layer recovers cleanly; recovery loops: break). This guarantees the loop terminates and the write lock is released, so a failed reorg degrades to 'stay on current fork + resync' instead of wedging the node.